### PR TITLE
doc: add markdown quotes to timeStepper doc

### DIFF
--- a/src/finch_interface.jl
+++ b/src/finch_interface.jl
@@ -182,7 +182,7 @@ end
     timeStepper(type; cfl=0)
 
 Set the type of time stepping method and optionally the CFL number.
-Options include EULER_EXPLICIT, EULER_IMPLICIT, CRANK_NICHOLSON, RK4, LSRK4, PECE.
+Options include `EULER_EXPLICIT`, `EULER_IMPLICIT`, `CRANK_NICHOLSON`, `RK4`, `LSRK4`, `PECE`.
 If no CFL number is provided, one will be chosen based on the mesh and stepper type.
 """
 function timeStepper(type; cfl=0)


### PR DESCRIPTION
Fixes a rendering bug in the docs. The double `_`'s were getting rendered as italics.

![Screen Shot 2022-11-16 at 13 53 22](https://user-images.githubusercontent.com/1731829/202268390-7888f41f-6a0e-41a9-ba15-04713589f432.png)
